### PR TITLE
Fix CI: Update workspace persistance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ jobs:
             - ./node_modules
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   build:
@@ -55,7 +54,6 @@ jobs:
             yarn build
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   test:
@@ -102,7 +100,6 @@ jobs:
             yarn update-data
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   publish-new-version:


### PR DESCRIPTION
Showing the the screenshot. The step "test" got it's "dist" directory from workspace persistence

![](https://user-images.githubusercontent.com/516342/89125522-c708d480-d4e7-11ea-8987-d5b4f3844cce.png)

Solution:
The `whitelist` variable already defines "paths" entry. Removed the redundant one

```yml
whitelist: &whitelist
  paths:
```