### PR TITLE
Remove redundant path entries in the CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ jobs:
             - ./node_modules
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   build:
@@ -55,7 +54,6 @@ jobs:
             yarn build
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   test:
@@ -102,7 +100,6 @@ jobs:
             yarn update-data
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   publish-new-version:


### PR DESCRIPTION
As pointed out by @omrilotan in #25, the CircleCI config file included `path:` entries that were redundant because they already existed in the `whitelist` variable. This was tolerated by CircleCI in an earlier parser version, but they pushed an update where it stopped working.
