### PR TITLE
Fix scheduled releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ workflows:
   scheduled-release:
     triggers:
       - schedule:
-          cron: "37 18 * * *"
+          cron: "39 18 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ workflows:
   scheduled-release:
     triggers:
       - schedule:
-          cron: "31 18 * * *"
+          cron: "37 18 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,14 @@ defaults: &defaults
 whitelist: &whitelist
   paths:
     - .babelrc
+    - .clabot
     - .circleci/*
     - .eslintrc
     - .git/*
+    - .github/*
     - .gitignore
     - dist/*
+    - CLA.md
     - CONTRIBUTING.md
     - LICENSE
     - README.md


### PR DESCRIPTION
Scheduled releases were broken because new repo files were added that weren't in the CI file whitelist. This adds them.
