### PR TITLE
Fix module exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,6 +12,7 @@
     }
   },
   "presets": [["@babel/preset-env", {
+    "modules": "commonjs",
     "targets": {
       "browsers": [
         "last 2 chrome versions",
@@ -23,7 +24,8 @@
   "plugins": [
       "@babel/plugin-proposal-class-properties",
       "@babel/plugin-proposal-object-rest-spread",
-      "@babel/plugin-transform-classes"
+      "@babel/plugin-transform-classes",
+      "babel-plugin-add-module-exports"
   ]
 }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/preset-env": "^7.12.16",
     "@babel/register": "^7.12.13",
     "babel-loader": "^8.2.2",
+    "babel-plugin-add-module-exports": "^1.0.4",
     "babel-preset-power-assert": "^3.0.0",
     "eslint": "^7.19.0",
     "eslint-config-airbnb": "^16.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 import UserAgent from './user-agent';
 
 
-module.exports = UserAgent;
+export default UserAgent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,6 +1337,11 @@ babel-loader@^8.2.2:
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
+babel-plugin-add-module-exports@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.4.tgz#6caa4ddbe1f578c6a5264d4d3e6c8a2720a7ca2b"
+  integrity sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==
+
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"


### PR DESCRIPTION
Following [Kill CommonJS default export behaviour #2212](https://github.com/babel/babel/issues/2212), babel always exports a default to `exports.default`. This broke the `module.exports = UserAgent;` behavior after upgrading the babel version. This PR adds [babel-plugin-add-module-exports](https://www.npmjs.com/package/babel-plugin-add-module-exports) so that imports should now work as `import UserAgent from 'user-agents'` and `const UserAgent = require('user-agents')`.
