### PR TITLE
Add HugoPoi to the contributor list

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,6 +1,7 @@
 {
   "contributors": [
-    "sangaline"
+    "sangaline",
+    "HugoPoi"
   ],
   "message": "Thank you for making a contribution! We require new contributors to sign our [Contributor License Agreement (CLA)](https://github.com/intoli/user-agents/blob/master/CLA.md). Please review our [Contributing Guide](https://github.com/intoli/user-agents/blob/master/CONTRIBUTING.md) and make sure that you've followed the steps listed there."
 }


### PR DESCRIPTION
This adds @HugoPoi to the `.clabot` contributor list following him signing the CLA.
