### PR TITLE
Prevent dot-json being part of the published dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
           name: Install dot-json package
-          command: npm install dot-json
+          command: npm install --no-save dot-json
       - run:
           name: Write version to package.json
           command: $(yarn bin)/dot-json package.json version ${CIRCLE_TAG:1}


### PR DESCRIPTION
dot-json has a sub-dependency without a license which means we are unable to use it.

Using [--no-save](https://docs.npmjs.com/cli/v9/commands/npm-install?v=true#:~:text=your%20optionalDependencies.-,%2D%2Dno%2Dsave,-%3A%20Prevents%20saving%20to) should prevent the package.json being polluted just before the publish happens.

Fixes #43

**Please check the boxes below to confirm that you have completed these steps:**

* [x] I have read and followed the [Contribution Agreement](https://github.com/intoli/user-agents/blob/master/CONTRIBUTING.md).
* [x] I have signed the project [Contributor License Agreement](https://github.com/intoli/user-agents/blob/master/CONTRIBUTING.md).
