### PR TITLE
Enable v2 alpha prereleases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
 
     jobs:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,13 +181,13 @@ workflows:
       - checkout:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*/
             branches:
               ignore: /.*/
       - lint:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*/
             branches:
               ignore: /.*/
           requires:
@@ -195,7 +195,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*/
             branches:
               ignore: /.*/
           requires:
@@ -203,7 +203,7 @@ workflows:
       - test:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*/
             branches:
               ignore: /.*/
           requires:
@@ -211,7 +211,7 @@ workflows:
       - deploy:
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*/
             branches:
               ignore: /.*/
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,19 +172,19 @@ workflows:
       - lint:
           filters:
             tags:
-              ignore: /v[0-9]+(\.[0-9]+)*/
+              ignore: /v[0-9]+(\.[0-9]+)*.*/
           requires:
             - checkout
       - build:
           filters:
             tags:
-              ignore: /v[0-9]+(\.[0-9]+)*/
+              ignore: /v[0-9]+(\.[0-9]+)*.*/
           requires:
             - checkout
       - test:
           filters:
             tags:
-              ignore: /v[0-9]+(\.[0-9]+)*/
+              ignore: /v[0-9]+(\.[0-9]+)*.*/
           requires:
             - build
 
@@ -193,13 +193,13 @@ workflows:
       - checkout:
           filters:
             tags:
-              only: /v[2-9](\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*.*/
             branches:
               ignore: /.*/
       - lint:
           filters:
             tags:
-              only: /v[2-9](\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*.*/
             branches:
               ignore: /.*/
           requires:
@@ -207,7 +207,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /v[2-9](\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*.*/
             branches:
               ignore: /.*/
           requires:
@@ -215,7 +215,7 @@ workflows:
       - test:
           filters:
             tags:
-              only: /v[2-9](\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*.*/
             branches:
               ignore: /.*/
           requires:
@@ -223,7 +223,7 @@ workflows:
       - deploy:
           filters:
             tags:
-              only: /v[2-9](\.[0-9]+)*/
+              only: /v[2-9](\.[0-9]+)*.*/
             branches:
               ignore: /.*/
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,20 @@ jobs:
             # but we want to publish anyway to stay on a regular schedule.
             git commit -m 'Regularly scheduled user agent data update.' || true
       - run:
-          name: Bump the patch version and trigger a new release
-          command: npm version patch && git push && git push --tags
+          name: Bump the patch (or prelease) version and trigger a new release
+          command: |
+            # Version, for example: `v2.0.0-alpha.0` or `v2.0.0`.
+            CURRENT_VERSION=$(npm list --depth=0 user-agents | grep user-agents | awk -F'[@ ]' '{print $2}')
+            if [[ $CURRENT_VERSION == *-* ]]; then
+              # A hyphen means we're a prelease and want to bump the prerelease version.
+              npm version prerelease
+            else
+              # Otherwise, this is a normal release and we bump the patch version.
+              npm version patch
+            fi
+            npm version patch
+            git push
+            git push --tags
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
               # Otherwise, this is a normal release and we bump the patch version.
               npm version patch
             fi
-            npm version patch
+
             git push
             git push --tags
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ workflows:
   scheduled-release:
     triggers:
       - schedule:
-          cron: '00 06 * * *'
+          cron: '30 06 * * *'
           filters:
             branches:
               only:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-agents",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "A JavaScript library for generating random user agents. ",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "user-agents",
   "version": "2.0.0-alpha.3",
   "description": "A JavaScript library for generating random user agents. ",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "repository": "git@github.com:intoli/user-agents.git",
   "author": "Intoli, LLC <contact@intoli.com>",
   "files": [
@@ -13,8 +13,8 @@
     "!src/user-agents.json.gz"
   ],
   "exports": {
-    "import": "dist/index.js",
-    "require": "dist/index.cjs"
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
   },
   "license": "BSD-2-Clause",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-agents",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-alpha.5",
   "description": "A JavaScript library for generating random user agents. ",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-agents",
-  "version": "1.1.9",
+  "version": "2.0.0-alpha.0",
   "description": "A JavaScript library for generating random user agents. ",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-agents",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "A JavaScript library for generating random user agents. ",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-agents",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "A JavaScript library for generating random user agents. ",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-agents",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0-alpha.4",
   "description": "A JavaScript library for generating random user agents. ",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -26,5 +26,5 @@ export default defineConfig({
   //   * https://github.com/egoist/tsup/issues/992#issuecomment-1763540165
   splitting: true,
   sourcemap: true,
-  target: 'node8',
+  target: 'esnext',
 });


### PR DESCRIPTION
This bumps the package version to `v2.0.0-alpha.5` on `main`, and sets up CI to do nightly builds and releases which bump the prerelease version. These nightly releases will continue until the `v2.0.0` release is ready, then we'll start doing nightly patch releases of `v2.0.x`. We'll continue the legacy `v1` releases for a while, but these will eventually be deprecated and discontinued.

The alpha releases may contain breaking changes, they're prereleases.
