### PR TITLE
Explicitly set the upstream branch before pushing updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
               npm version patch
             fi
 
-            git push
+            git push --set-upstream origin main
             git push --tags
 
 workflows:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "postbuild": "yarn gunzip-data && cp src/user-agents.json dist/",
     "gunzip-data": "node --loader ts-node/esm src/gunzip-data.ts src/user-agents.json.gz",
     "lint": "eslint src/ && prettier --check src/",
-    "postversion": "git push && git push --tags",
     "test": "NODE_ENV=testing mocha --exit --require @babel/register --extensions '.ts, .js'",
     "update-data": "node --loader ts-node/esm src/update-data.ts src/user-agents.json.gz"
   },


### PR DESCRIPTION
This removes the `postversion` script which was automatically calling `git push`, and instead handles it manually and sets the upstream.
