### PR TITLE
Add language and oscpu to user agent data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ workflows:
   scheduled-release:
     triggers:
       - schedule:
-          cron: '38 12 * * *'
+          cron: '30 06 * * *'
           filters:
             branches:
               only:

--- a/src/update-data.ts
+++ b/src/update-data.ts
@@ -96,10 +96,6 @@ const getUserAgentTable = async (limit = 1e4) => {
       profile.weight = weight;
       delete profile.sessionId;
 
-      // Deleting these because they weren't in the old format, but we should leave them in...
-      delete profile.language;
-      delete profile.oscpu;
-
       // Find the device category.
       const parser = new UAParser(profile.userAgent);
       const device = parser.getDevice();

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -22,6 +22,8 @@ export interface UserAgentData {
     downlinkMax?: number | null;
     type?: 'cellular' | 'wifi';
   };
+  language?: string | null;
+  oscpu?: string | null;
   platform:
     | 'iPad'
     | 'iPhone'


### PR DESCRIPTION
These are available in the new analytics script, but were left out for rigorous backward compatibility with v1. This adds them in for the v2 branch.
