### PR TITLE
Extend the CI timeout on the update step from 10 minutes to 30 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ jobs:
           key: dependency-cache-v2-{{ checksum "yarn.lock" }}
       - run:
           name: Update the user agents data
+          no_output_timeout: 30m
           command: |
             yarn update-data
       - store_artifacts:


### PR DESCRIPTION
The update step started timing out. This is a mitigation until I have a chance to do more extensive updates.
